### PR TITLE
Fix attribute handling from the command line and config file.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ dev = [
     "pytest-cov",
     "types-docopt"
 ]
+
+[tool.ruff]
+line-length = 120

--- a/wdidt/__main__.py
+++ b/wdidt/__main__.py
@@ -114,7 +114,7 @@ def main(ago, force, verbose, dry_run, attributes, root_dir, config_file):
             cmd_attribs = json.loads(attributes)
             log.debug(f"Attributes parsed from command line: {cmd_attribs}")
         except json.JSONDecodeError as e:
-            log.error(f"Failed to parse attributes: {e}")
+            log.exception(f"Failed to parse attributes: {e}")
             raise click.BadParameter("Invalid format for attributes. Use JSON format.")
     attribs.update(cmd_attribs)
     # ensure we have a name attribute

--- a/wdidt/__main__.py
+++ b/wdidt/__main__.py
@@ -13,9 +13,7 @@ import click
 from wdidt.new_day import create_new_day
 import getpass
 
-logging.basicConfig(
-    format="[%(asctime)s]%(name)s.%(levelname)s: %(message)s", level=logging.ERROR
-)
+logging.basicConfig(format="[%(asctime)s]%(name)s.%(levelname)s: %(message)s", level=logging.ERROR)
 
 log = logging.getLogger(__name__)
 
@@ -91,9 +89,7 @@ def main(ago, force, verbose, dry_run, attributes, root_dir, config_file):
             log.info(f"Using configuration file: {config_file}")
             config.update(json.loads(Path(config_file).read_text()))
         else:
-            log.info(
-                f"Configuration file {config_file} does not exist.\n  - Creating a default configuration file."
-            )
+            log.info(f"Configuration file {config_file} does not exist.\n  - Creating a default configuration file.")
             config = {
                 "attributes": {"name": getpass.getuser()},
                 "root-dir": str(Path.home().joinpath(".wdidt").absolute()),
@@ -109,10 +105,22 @@ def main(ago, force, verbose, dry_run, attributes, root_dir, config_file):
         log_day = datetime.date.today() - datetime.timedelta(days=ago)
         log.debug(f"Log file day is being set to {log_day}.")
 
-    # make sure we have the attributes from the config file, and at minimum the 'name' attribute.
-    attributes = config.get("attributes", {})
-    if "name" not in attributes:
-        attributes.update({"name": getpass.getuser()})
+    # make sure we have the attributes from the config file...
+    attribs = config.get("attributes", {})
+    # override the attributes from those specified on the command line
+    cmd_attribs = {}
+    if attributes:
+        try:
+            cmd_attribs = json.loads(attributes)
+            log.debug(f"Attributes parsed from command line: {cmd_attribs}")
+        except json.JSONDecodeError as e:
+            log.error(f"Failed to parse attributes: {e}")
+            raise click.BadParameter("Invalid format for attributes. Use JSON format.")
+    attribs.update(cmd_attribs)
+    # ensure we have a name attribute
+    if "name" not in attribs:
+        attribs.update({"name": getpass.getuser()})
+        log.warning("No 'name' attribute found in configuration file nor command line. Using the current user name.")
 
     root_folder = Path(root_dir).absolute()
     log.debug(f"Root folder is set to {root_folder}")
@@ -122,7 +130,7 @@ def main(ago, force, verbose, dry_run, attributes, root_dir, config_file):
         log_day=log_day,
         force=force,
         dry_run=dry_run,
-        attribs=attributes,
+        attribs=attribs,
         verbose=verbose,
         root_dir=root_folder,
     )


### PR DESCRIPTION
This pull request introduces several changes to improve code readability, configuration handling, and logging behavior in the `wdidt` project. It also adds a new configuration section for the Ruff linter in `pyproject.toml`. The most important changes include enhancing attribute handling in the `main` function, refining logging setup, and adding Ruff configuration.

### Configuration Enhancements:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R31-R33): Added a `[tool.ruff]` section with a `line-length` setting of 120 to configure the Ruff linter.

### Code Improvements:
* [`wdidt/__main__.py`](diffhunk://#diff-acc4e106d2c5bdea3ad58db5ba6bb1d9fd0e4c6af58c1d8cffe39d3733f4e7b5L112-R123): Enhanced the `main` function to handle attributes more robustly. Attributes specified via the command line are now parsed as JSON, validated, and merged with those from the configuration file. Added error handling for invalid JSON input and ensured a default `name` attribute is set if missing.
* [`wdidt/__main__.py`](diffhunk://#diff-acc4e106d2c5bdea3ad58db5ba6bb1d9fd0e4c6af58c1d8cffe39d3733f4e7b5L125-R133): Updated the `attribs` parameter in the call to the `log_day` function to reflect the new attribute handling logic.

### Logging Refinements:
* [`wdidt/__main__.py`](diffhunk://#diff-acc4e106d2c5bdea3ad58db5ba6bb1d9fd0e4c6af58c1d8cffe39d3733f4e7b5L16-R16): Simplified the `logging.basicConfig` setup by removing unnecessary line breaks.
* [`wdidt/__main__.py`](diffhunk://#diff-acc4e106d2c5bdea3ad58db5ba6bb1d9fd0e4c6af58c1d8cffe39d3733f4e7b5L94-R92): Refined logging messages to improve readability and consistency, particularly when handling configuration files.